### PR TITLE
Avoid duplicate symbols when linking with new V8

### DIFF
--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -199,8 +199,8 @@
 // be changed to a new, unique identifier name.  In particular "head" is not
 // allowed.
 
-#define ABSL_OPTION_USE_INLINE_NAMESPACE 0
-#define ABSL_OPTION_INLINE_NAMESPACE_NAME head
+#define ABSL_OPTION_USE_INLINE_NAMESPACE 1
+#define ABSL_OPTION_INLINE_NAMESPACE_NAME arangodb
 
 // ABSL_OPTION_HARDENED
 //


### PR DESCRIPTION
This change seems necessary to avoid having duplicate symbols when linking with the new version of V8, which also uses absl.