### PR TITLE
__is_trivially_relocatable is deprecated

### DIFF
--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -501,7 +501,8 @@ using swap_internal::StdSwapIsUnconstrained;
     !(defined(__clang__) && (defined(_WIN32) || defined(_WIN64)))
 template <class T>
 struct is_trivially_relocatable
-    : std::integral_constant<bool, __is_trivially_relocatable(T)> {};
+    : std::integral_constant<bool, __builtin_is_cpp_trivially_relocatable(T)> {
+};
 #else
 // Otherwise we use a fallback that detects only those types we can feasibly
 // detect. Any time that has trivial move-construction and destruction


### PR DESCRIPTION
This patch helps arangodb compile with a more recent compiler (clang-20, 21, 22) as it removes the reference to the now deprecated `__is_trivially_relocatable`; 